### PR TITLE
update go-reuseport

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.6.0: QmPsBtdPF4KubRJA6hYRZuZTaipVahT1M7kgHQbNMYttSm
+1.6.1: Qmazcq5ZXnyP5smvUquM8dAro6ZAppExxyV7Z3URq3dzin

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmdvAtoUu3G2roG9sa957FqJSBTykm6TxTTPWURsrvfnbQ",
+      "hash": "QmeivQB6J3BNaUCBDvSkVwUvokgav6JSrngDb6xGMdjTwm",
       "name": "go-reuseport",
-      "version": "0.0.0"
+      "version": "0.1.0"
     },
     {
       "author": "whyrusleeping",

--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
   "language": "go",
   "license": "MIT",
   "name": "go-libp2p-transport",
-  "version": "1.6.0"
+  "version": "1.6.1"
 }


### PR DESCRIPTION
previous version included buggy eventfd which is my fault as I forgot to push it
yesterday and asked whyrusleeping to bubble the dependencies
