### PR TITLE
reuseport.Dialer does not have Context support

### DIFF
--- a/tcp.go
+++ b/tcp.go
@@ -188,7 +188,7 @@ func (d *tcpDialer) reuseDial(ctx context.Context, raddr ma.Multiaddr) (manet.Co
 		return nil, err
 	}
 
-	con, err := d.rd.DialContext(ctx, network, netraddr)
+	con, err := d.rd.Dial(network, netraddr)
 	if err == nil {
 		logdial["reuseport"] = "success"
 		rpev.Done()


### PR DESCRIPTION
I guess this kind of slipped through with the other context additions, but I couldn't find any hint that go-reuseport ever supported context, so I propose to change this one back.
