### PR TITLE
Update go-reuseport

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.6.1: Qmazcq5ZXnyP5smvUquM8dAro6ZAppExxyV7Z3URq3dzin
+1.6.2: QmXfdx9CctuhcwstiEDekR6FLvU4eHv3t2UHGVXTEbjbBZ

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmeivQB6J3BNaUCBDvSkVwUvokgav6JSrngDb6xGMdjTwm",
+      "hash": "QmZQWawFZmno5KsJ7g9SJepH4H3THbYpajveTxF1nEXtLv",
       "name": "go-reuseport",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     {
       "author": "whyrusleeping",

--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
   "language": "go",
   "license": "MIT",
   "name": "go-libp2p-transport",
-  "version": "1.6.1"
+  "version": "1.6.2"
 }


### PR DESCRIPTION
Fixes crash if EpollWait returns max number of events
