### PR TITLE
Update Travis CI to use standard test script and go 1.9.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,13 @@ language: go
 sudo: false
 
 go:
-  - 1.8
+  - 1.9.x
 
 before_install:
-  - go get github.com/mattn/goveralls
-  - go get golang.org/x/tools/cmd/cover
-  - go get github.com/whyrusleeping/gx
-  - go get github.com/whyrusleeping/gx-go
-
-install:
-  - gx --verbose install --global
-  - gx-go rewrite
+ - make deps
 
 script:
-  - $HOME/gopath/bin/goveralls -service="travis-ci"
+  - bash <(curl -s https://raw.githubusercontent.com/ipfs/ci-helpers/master/travis-ci/run-standard-tests.sh)
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ sudo: false
 go:
   - 1.9.x
 
-before_install:
+install:
  - make deps
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,6 @@ script:
 cache:
     directories:
         - $GOPATH/src/gx
+
+notifications:
+  email: false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+gx:
+	go get github.com/whyrusleeping/gx
+	go get github.com/whyrusleeping/gx-go
+
+deps: gx
+	gx --verbose install --global
+	gx-go rewrite
+
+publish:
+	gx-go rewrite --undo
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  range: "50...100"
+comment: off


### PR DESCRIPTION
This also switches from goveralls to codecov.