### PR TITLE
fix: fully close streams before returning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: go
 sudo: false
 
 go:
-  - 1.9.x
+  - 1.11.x
 
 install:
  - make deps


### PR DESCRIPTION
The other side will fail to send an EOF if we end up closing the connection the
second we're done reading from the stream.

(fixes test flakes in the TCP transport)