### PR TITLE
Fix a bug in SubtestPingPong where the connection is sometimes closed too early

### DIFF
--- a/test/transport.go
+++ b/test/transport.go
@@ -178,7 +178,6 @@ func SubtestPingPong(t *testing.T, ta, tb tpt.Transport, maddr ma.Multiaddr, pee
 			t.Error(err)
 			return
 		}
-		defer c.Close()
 
 		var sWg sync.WaitGroup
 		for i := 0; i < streams; i++ {


### PR DESCRIPTION
Unlike `Stream.Close`, `Conn.Close` closes both ends of the connection. The first call to `c.Close` was sometimes causing both ends of the connection to close before the other end was done reading/writing. This was causing test failures for [go-libp2p-webrtc-direct](https://github.com/libp2p/go-libp2p-webrtc-direct).

This PR simply removes the first call to `c.Close` which prevents the connection from being closed until after the other end is done reading/writing.